### PR TITLE
Add batch_metrics function and unit tests.

### DIFF
--- a/metricpublisher/lambda_handler.py
+++ b/metricpublisher/lambda_handler.py
@@ -11,12 +11,12 @@ CLIENT = boto3.client('logs')
 CONVERT_SECONDS_TO_MILLIS_FACTOR = 1000
 
 
-def get_LOG_GROUP_NAME():
+def get_log_group_name():
     """Get the log group name."""
-    return config.LOG_GROUP_NAME
+    return config.log_group_name
 
 
-def get_NAMESPACE():
+def get_namespace():
     """Get the namespace."""
     return config.NAMESPACE_PARAM
 
@@ -43,13 +43,13 @@ def log_event(event, context):
         return _error_response(err)
     request_id = event["request_id"]
     event = str(event)
-    new_log_stream_name = '_'.join((get_NAMESPACE(), request_id))
+    new_log_stream_name = '_'.join((get_namespace(), request_id))
     CLIENT.create_log_stream(
-        logGroupName=get_LOG_GROUP_NAME(),
+        logGroupName=get_log_group_name(),
         logStreamName=new_log_stream_name
     )
     CLIENT.put_log_events(
-        logGroupName=get_LOG_GROUP_NAME(),
+        logGroupName=get_log_group_name(),
         logStreamName=new_log_stream_name,
         logEvents=[
             {
@@ -78,15 +78,9 @@ def batch_metrics(log_stream_names):
         return metrics_list
     for stream in log_stream_names:
         log_event = CLIENT.get_log_events(
-            logGroupName=get_LOG_GROUP_NAME(),
+            logGroupName=get_log_group_name(),
             logStreamName=stream
         )
-        while len(log_event['events']) == 0:
-            time.sleep(1)  # Events will not show if put recently
-            log_event = CLIENT.get_log_events(
-                logGroupName=get_LOG_GROUP_NAME(),
-                logStreamName=stream
-            )
         event_message = ast.literal_eval(log_event['events'][0]['message'])
         for metric in event_message['metric_data']:
             metrics_list.append(metric)

--- a/test/unit/events.py
+++ b/test/unit/events.py
@@ -375,3 +375,67 @@ def dimension_item_wrong_property():
             }
         ]
     }
+
+@pytest.fixture()
+def simple_metric_before():
+    return {
+        "metric_name": "theMetricName",
+        "value": 123,
+    }
+
+@pytest.fixture()
+def simple_metric_after_expected():
+    return {
+        "MetricName":"theMetricName",
+        "Value": 123,
+    }
+
+@pytest.fixture()
+def complex_metric_before():
+    return {
+        "metric_name": "theMetricname",
+        "dimensions": [
+            {
+                "name": "thename1",
+                "value": "thevalue1"
+            },
+            {
+                "name": "thename2",
+                "value": "thevalue2"
+            }
+        ],
+        "timestamp": 1528236844480,
+        "statistic_values": {
+            "sample_count": 12.17,
+            "sum": 12.17,
+            "minimum": 12.17,
+            "maximum": 12.17
+        },
+        "unit": "Seconds",
+        "storage_resolution": 12
+    }
+
+@pytest.fixture()
+def complex_metric_after_expected():
+    return {
+        "MetricName": "theMetricname",
+        "Dimensions": [
+            {
+                "Name": "thename1",
+                "Value": "thevalue1"
+            },
+            {
+                "Name": "thename2",
+                "Value": "thevalue2"
+            }
+        ],
+        "Timestamp": 1528236844480,
+        "StatisticValues": {
+            "SampleCount": 12.17,
+            "Sum": 12.17,
+            "Minimum": 12.17,
+            "Maximum": 12.17
+        },
+        "Unit": "Seconds",
+        "StorageResolution": 12
+    }

--- a/test/unit/test_handler.py
+++ b/test/unit/test_handler.py
@@ -105,10 +105,10 @@ def test_log_event_client_function_calls(mocker):
     current_time = int(time.time()*CONVERT_SECONDS_TO_MILLIS_FACTOR)
     metricpublisher.lambda_handler.get_current_time.return_value = current_time
     mocker.patch.object(metricpublisher.lambda_handler,'CLIENT')
-    mocker.patch.object(metricpublisher.lambda_handler, 'get_LOG_GROUP_NAME')
-    mocker.patch.object(metricpublisher.lambda_handler, 'get_NAMESPACE')
-    metricpublisher.lambda_handler.get_LOG_GROUP_NAME.return_value = 'metricPublisherAppLogGroup'
-    metricpublisher.lambda_handler.get_NAMESPACE.return_value = 'metricPublisherAppNamespace'
+    mocker.patch.object(metricpublisher.lambda_handler, 'get_log_group_name')
+    mocker.patch.object(metricpublisher.lambda_handler, 'get_namespace')
+    metricpublisher.lambda_handler.get_log_group_name.return_value = 'metricPublisherAppLogGroup'
+    metricpublisher.lambda_handler.get_namespace.return_value = 'metricPublisherAppNamespace'
     data = events.standard_valid_input()
     event = str(data)
     log_events = [
@@ -152,11 +152,11 @@ def test_batch_metrics_client_function_call(mocker):
     }
     batch_metrics_expected_response = list(itertools.repeat(single_metric,num_iters))
     mocker.patch.object(metricpublisher.lambda_handler, 'CLIENT')
-    mocker.patch.object(metricpublisher.lambda_handler, 'get_LOG_GROUP_NAME')
-    mocker.patch.object(metricpublisher.lambda_handler, 'get_NAMESPACE')
+    mocker.patch.object(metricpublisher.lambda_handler, 'get_log_group_name')
+    mocker.patch.object(metricpublisher.lambda_handler, 'get_namespace')
     metricpublisher.lambda_handler.CLIENT.get_log_events.return_value = get_log_events_response
-    metricpublisher.lambda_handler.get_LOG_GROUP_NAME.return_value = log_group_name
-    metricpublisher.lambda_handler.get_NAMESPACE.return_value = namespace
+    metricpublisher.lambda_handler.get_log_group_name.return_value = log_group_name
+    metricpublisher.lambda_handler.get_namespace.return_value = namespace
     assert metricpublisher.lambda_handler.batch_metrics(stream_names) == batch_metrics_expected_response
     metricpublisher.lambda_handler.CLIENT.get_log_events.assert_called_with(logGroupName=log_group_name,logStreamName=stream_name)
 
@@ -207,11 +207,11 @@ def test_batch_metrics_multiple_metrics(mocker):
     combined_metrics_list = [single_metric_1,single_metric_2,single_metric_3]
     batch_metrics_expected_response = combined_metrics_list + combined_metrics_list + combined_metrics_list
     mocker.patch.object(metricpublisher.lambda_handler, 'CLIENT')
-    mocker.patch.object(metricpublisher.lambda_handler, 'get_LOG_GROUP_NAME')
-    mocker.patch.object(metricpublisher.lambda_handler, 'get_NAMESPACE')
+    mocker.patch.object(metricpublisher.lambda_handler, 'get_log_group_name')
+    mocker.patch.object(metricpublisher.lambda_handler, 'get_namespace')
     metricpublisher.lambda_handler.CLIENT.get_log_events.return_value = get_log_events_response
-    metricpublisher.lambda_handler.get_LOG_GROUP_NAME.return_value = log_group_name
-    metricpublisher.lambda_handler.get_NAMESPACE.return_value = namespace
+    metricpublisher.lambda_handler.get_log_group_name.return_value = log_group_name
+    metricpublisher.lambda_handler.get_namespace.return_value = namespace
     assert metricpublisher.lambda_handler.batch_metrics(stream_names) == batch_metrics_expected_response
 
 def _assert_error_response(result, error_type):


### PR DESCRIPTION
This commit adds the implementation of the batch_metrics
function and a couple of corresponding unit tests.
metric_publisher, when implemented, will call batch_metrics
to form a list of metrics to put to cloudwatch.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
